### PR TITLE
Add class variable to merge for class

### DIFF
--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -21,5 +21,5 @@
          ?? $label]) }}>
     </div>
 @else
-    <input {{ $attributes->merge(['type' => 'text', 'class' => 'focus:ring-neutral-dark focus:border-neutral-dark block w-full shadow-sm sm:text-sm border-neutral-light rounded-md', 'placeholder' => $placeholder ?? null]) }}>
+    <input {{ $attributes->merge(['type' => 'text', 'class' => 'focus:ring-neutral-dark focus:border-neutral-dark block w-full shadow-sm sm:text-sm border-neutral-light rounded-md ' . $class, 'placeholder' => $placeholder ?? null]) }}>
 @endif


### PR DESCRIPTION
Without this variable, the class attributes aren't being merged. This is causing the padding issue for the search box.