### PR TITLE
Fix accordion heading component namespace

### DIFF
--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -15,7 +15,7 @@
     role="region"
     {{ $attributes->merge(['class' => 'border border-black rounded-md shadow']) }}
 >
-    <x-library:heading.2>
+    <x-library::heading.2>
         <button
                 x-on:click="expanded = !expanded"
                 :aria-expanded="expanded"
@@ -25,7 +25,7 @@
             <span x-show="expanded" aria-hidden="true" class="ml-4">&minus;</span>
             <span x-show="!expanded" aria-hidden="true" class="ml-4">&plus;</span>
         </button>
-    </x-library:heading.2>
+    </x-library::heading.2>
 
     <div x-show="expanded" x-collapse>
         <div class="pb-4 px-6">


### PR DESCRIPTION
## Summary
- fix the accordion item heading Blade component namespace
- update both opening and closing tags to use the package component syntax

## Validation
- composer install --no-interaction --prefer-dist
- vendor/bin/pest
- vendor/bin/testbench view:clear
- vendor/bin/testbench view:cache *(currently still fails on existing `heading.3` component resolution in `resources/views/components/card/index.blade.php`)*