### PR TITLE
Backport accordion heading component namespace fix to 1.x

### DIFF
--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -15,7 +15,7 @@
     role="region"
     {{ $attributes->merge(['class' => 'border border-black rounded-md shadow']) }}
 >
-    <x-library:heading.2>
+    <x-library::heading.2>
         <button
                 x-on:click="expanded = !expanded"
                 :aria-expanded="expanded"
@@ -25,7 +25,7 @@
             <span x-show="expanded" aria-hidden="true" class="ml-4">&minus;</span>
             <span x-show="!expanded" aria-hidden="true" class="ml-4">&plus;</span>
         </button>
-    </x-library:heading.2>
+    </x-library::heading.2>
 
     <div x-show="expanded" x-collapse>
         <div class="pb-4 px-6">


### PR DESCRIPTION
## Summary
- backport the accordion item Blade namespace fix to `1.x`
- replace malformed `<x-library:heading.2>` tags with `<x-library::heading.2>`
- align `1.x` with the fix already present on `main`

## Validation
- verified the `resources/views/components/accordion/item.blade.php` diff matches the `main` branch fix
- confirmed the malformed single-colon tag is removed from the `1.x` backport branch